### PR TITLE
Replaced markdown renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react-native-camera": "3.17.0",
     "react-native-device-info": "5.5.3",
     "react-native-global-props": "1.1.5",
-    "react-native-markdown-renderer": "3.2.8",
+    "react-native-markdown-display": "git+https://github.com/felfele/react-native-markdown-display.git",
     "react-native-parse-html": "2.2.6",
     "react-native-permissions": "2.0.9",
     "react-native-picker-select": "6.3.4",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react-native-camera": "3.17.0",
     "react-native-device-info": "5.5.3",
     "react-native-global-props": "1.1.5",
-    "react-native-markdown-display": "git+https://github.com/felfele/react-native-markdown-display.git",
+    "react-native-markdown-display": "6.1.4",
     "react-native-parse-html": "2.2.6",
     "react-native-permissions": "2.0.9",
     "react-native-picker-select": "6.3.4",

--- a/src/ui/card/CardMarkdown.tsx
+++ b/src/ui/card/CardMarkdown.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Linking } from 'react-native';
 
-import Markdown from 'react-native-markdown-renderer';
+import Markdown from 'react-native-markdown-display';
 import { ErrorBoundary } from '../misc/ErrorBoundary';
 
 export const CardMarkdown = (props: { text: string }) => (


### PR DESCRIPTION
Replaced `react-native-markdown-renderer` with `react-native-markdown-display`

See also https://github.com/iamacup/react-native-markdown-display/pull/80